### PR TITLE
feat: add reduced rates teleportation tracking

### DIFF
--- a/TrackyTrack/CharacterConfig.cs
+++ b/TrackyTrack/CharacterConfig.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game.ClientState.Objects.SubKinds;
+using System.Collections.Concurrent;
 using TrackyTrack.Data;
 
 namespace TrackyTrack;
@@ -21,6 +22,9 @@ public class CharacterConfiguration
 
     public uint Teleports = 0;
     public uint TeleportCost = 0;
+    public ConcurrentDictionary<TeleportBuff, uint> TeleportsWithBuffs = new();
+    // Teleport savings (original cost - discounted cost) for each buff type
+    public ConcurrentDictionary<TeleportBuff, uint> TeleportSavingsWithBuffs = new();
     // Tickets
     public uint TeleportsAetheryte = 0;
     public uint TeleportsGC = 0;

--- a/TrackyTrack/Data/Teleport.cs
+++ b/TrackyTrack/Data/Teleport.cs
@@ -1,0 +1,64 @@
+using Dalamud.Game.ClientState.Statuses;
+
+namespace TrackyTrack.Data;
+
+[Serializable]
+public enum TeleportBuff : uint
+{
+    None = 0,
+
+    // Free company actions:
+    ReducedRatesI = 1,   // 20% discount
+    ReducedRatesII = 2,  // 30% discount
+    ReducedRatesIII = 3, // 40% discount
+}
+
+public static class TeleportBuffExtension
+{
+    public static string ToName(this TeleportBuff buff)
+    {
+        return (buff) switch
+        {
+            TeleportBuff.None => "None",
+            TeleportBuff.ReducedRatesI => "Reduced Rates (20%)",
+            TeleportBuff.ReducedRatesII => "Reduced Rates II (30%)",
+            TeleportBuff.ReducedRatesIII => "Reduced Rates III (40%)",
+            _ => "Unknown"
+        };
+    }
+
+    public static TeleportBuff FromStatusList(StatusList statusList)
+    {
+        foreach (var item in statusList)
+        {
+            // "Reduced Rates"
+            if (item.StatusId == 364)
+            {
+                switch (item.StackCount)
+                {
+                    case 40:
+                        return TeleportBuff.ReducedRatesIII;
+                    case 30:
+                        return TeleportBuff.ReducedRatesII;
+                    case 20:
+                        return TeleportBuff.ReducedRatesI;
+                }
+            }
+        }
+
+        return TeleportBuff.None;
+    }
+
+    public static uint ToOriginalCost(this TeleportBuff buff, uint discountedCost)
+    {
+        return (buff) switch
+        {
+            // I think FFXIV rounds down to the nearest gil when discounting,
+            // so round up when calculating original cost
+            TeleportBuff.ReducedRatesI => (uint)Math.Ceiling(discountedCost / 0.8),
+            TeleportBuff.ReducedRatesII => (uint)Math.Ceiling(discountedCost / 0.7),
+            TeleportBuff.ReducedRatesIII => (uint)Math.Ceiling(discountedCost / 0.6),
+            _ => discountedCost
+        };
+    }
+}

--- a/TrackyTrack/Windows/Main/MainWindow.Stats.cs
+++ b/TrackyTrack/Windows/Main/MainWindow.Stats.cs
@@ -1,5 +1,4 @@
 using Dalamud.Interface.Utility;
-using Microsoft.VisualBasic;
 using TrackyTrack.Data;
 
 namespace TrackyTrack.Windows.Main;
@@ -105,24 +104,13 @@ public partial class MainWindow
         if (teleportsWithout == 0)
             teleportsWithout = 1;
         
-        var buffed = new Dictionary<TeleportBuff, (long, long)>();
-        foreach (var buff in (TeleportBuff[]) Enum.GetValues(typeof(TeleportBuff)))
-        {
-            var count = characters.Sum(c => c.TeleportsWithBuffs.TryGetValue(buff, out var value) ? value : 0);
-            var savings = characters.Sum(c => c.TeleportSavingsWithBuffs.TryGetValue(buff, out var value) ? value : 0);
-            if (count == 0)
-                continue;
-
-            buffed[buff] = (count, savings);
-        }
-
         ImGui.TextColored(ImGuiColors.DalamudViolet, "Teleport:");
         ImGui.Indent(10.0f);
         if (teleports > 0)
         {
-            if (ImGui.BeginTable($"##TeleportStatsTable", 2, 0, new Vector2(300 * ImGuiHelpers.GlobalScale, 0)))
+            if (ImGui.BeginTable($"##TeleportStatsTable", 2, 0, new Vector2(450 * ImGuiHelpers.GlobalScale, 0)))
             {
-                ImGui.TableSetupColumn("##TeleportStat", 0, 1.1f);
+                ImGui.TableSetupColumn("##TeleportStat", 0, 0.6f);
                 ImGui.TableSetupColumn("##TeleportNum");
 
                 ImGui.TableNextColumn();
@@ -149,21 +137,37 @@ public partial class MainWindow
                 ImGui.TableNextRow();
                 ImGui.TableNextColumn();
 
-                #region Saving buffs
+                #region Savings
+                var buffed = new Dictionary<TeleportBuff, (long, long)>();
+                foreach (var buff in (TeleportBuff[]) Enum.GetValues(typeof(TeleportBuff)))
+                {
+                    var count = characters.Sum(c => c.TeleportsWithBuffs.TryGetValue(buff, out var value) ? value : 0);
+                    var savings = characters.Sum(c => c.TeleportSavingsWithBuffs.TryGetValue(buff, out var value) ? value : 0);
+                    if (count == 0)
+                        continue;
+
+                    buffed[buff] = (count, savings);
+                }
+
                 if (buffed.Count > 0)
                 {
                     ImGuiHelpers.ScaledDummy(5.0f);
                     ImGui.TableNextRow();
                     ImGui.TableNextColumn();
-                    ImGui.TextColored(ImGuiColors.HealerGreen, "Savings Buffs");
+                    ImGui.TextColored(ImGuiColors.HealerGreen, "Savings");
                     ImGui.Indent(10.0f);
 
+                    var currentBuff = Plugin.GetCurrentTeleportBuff();
                     foreach (var (buff, (count, savings)) in buffed)
                     {
                         ImGui.TableNextRow();
                         ImGui.TableNextColumn();
 
-                        ImGui.TextColored(ImGuiColors.HealerGreen, buff.ToName().Replace("%", "%%"));
+                        var color = ImGuiColors.HealerGreen;
+                        if (buff == currentBuff)
+                            color = ImGuiColors.DalamudYellow;
+
+                        ImGui.TextColored(color, buff.ToName().Replace("%", "%%"));
                         ImGui.TableNextColumn();
 
                         var stat = $"{count} times";


### PR DESCRIPTION
Tracks Reduced Rates, Reduced Rates II and Reduced Rates III teleport counts and teleport savings. The current buff is shown as yellow, which is nice since the game doesn't actually tell you what buff level you currently have.

Tested for Reduced Rates and Reduced Rates II, and I'm waiting on my friend to craft a Reduced Rates III company action so I can test that. If it's implemented the same way as the others though (which it almost definitely is) then it should already be handled by the code.

![image](https://github.com/Infiziert90/TrackyTrack/assets/11241812/821c650b-a9d4-42a3-88e4-9c5aab4b0d5f)

(The Reduced Rates III in the screenshot is faked since I haven't been able to test it yet)

Closes #2 